### PR TITLE
[Perf] set `Symbol.isConcatSpreadable` only when required 

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,9 +12,6 @@ var hasSymbols = require('has-symbols/shams')();
 var isConcatSpreadable = hasSymbols && Symbol.isConcatSpreadable;
 
 var empty = [];
-if (isConcatSpreadable) {
-	empty[isConcatSpreadable] = true;
-}
 var $concatApply = isConcatSpreadable ? callBind.apply($concat, empty) : null;
 var $concatCall = isConcatSpreadable ? null : callBind($concat, empty);
 
@@ -26,6 +23,9 @@ module.exports = isConcatSpreadable
 		for (var i = 0; i < arguments.length; i += 1) {
 			var arg = arguments[i];
 			if (arg && typeof arg === 'object' && typeof arg[isConcatSpreadable] === 'boolean') {
+				if (!empty[isConcatSpreadable]) {
+					empty[isConcatSpreadable] = true;
+				}
 				var arr = isArray(arg) ? $slice(arg) : [arg];
 				arr[isConcatSpreadable] = true; // shadow the property. TODO: use [[Define]]
 				arguments[i] = arr;


### PR DESCRIPTION
Context:
Issue: https://github.com/ljharb/safe-array-concat/issues/2

## Changes done in PR:
Since, we were facing issue on setting `Symbol.isConcatSpreadable` on initialisation, we just move this statement inside safeArrayConcat function & execute only when we get any value on which this symbol was already set. Since, reference is passed in callBind.apply(), setting symbol key later after apply() should also make working of $concatApply as expected.

## Steps to verify:
executed `npm test`
Existing 9 test cases were executed and all were passed.
Below code snippet was also executed:

```
const loadPackage = process.env.loadPackage==="true" || false;
const count = process.env.count || 100;

if (loadPackage) {
    require('safe-array-concat');
}

const runScript = () => {
    console.log(`Running test`);

    // creating sample array of 50k size with dummy data
    const sampleArray = [];
    const arraySize = 1000*50;
    for (let i = 0; i<arraySize; i++) sampleArray.push(i);

    // Actual test:
    console.time("concatOperation");
    for (let i =0; i<count; i++) {
        sampleArray.concat(sampleArray); // <--- Testing impact on this operation's performance
    }
    console.timeEnd("concatOperation");
}

runScript();
```

**Test execution results**::
`loadPackage=true count=200 node safe-test.js` :: 114 ms
`loadPackage=false count=200 node safe-test.js` :: 113 ms
`loadPackage=true count=500 node safe-test.js` :: 268 ms
`loadPackage=false count=500 node safe-test.js` :: 275 ms
(No impact of requiring package on our application now)
